### PR TITLE
[ADD] emotion theme에 타입 추가

### DIFF
--- a/styles/emotion.d.ts
+++ b/styles/emotion.d.ts
@@ -1,11 +1,9 @@
 import '@emotion/react';
+import theme from './theme';
 
-interface ColorsType {
-  [key: string]: string;
-}
+type ExtendTheme = typeof theme;
 
 declare module '@emotion/react' {
-  export interface Theme {
-    colors: ColorsType;
-  }
+  // eslint-disable-next-line @typescript-eslint/no-empty-interface
+  export interface Theme extends ExtendTheme {}
 }

--- a/styles/emotion.d.ts
+++ b/styles/emotion.d.ts
@@ -1,0 +1,11 @@
+import '@emotion/react';
+
+interface ColorsType {
+  [key: string]: string;
+}
+
+declare module '@emotion/react' {
+  export interface Theme {
+    colors: ColorsType;
+  }
+}

--- a/styles/theme.ts
+++ b/styles/theme.ts
@@ -1,25 +1,27 @@
+const colors = {
+  blue_light: '#87b1f3',
+  blue_0: '#4c80f1',
+  blue_dark: '#2c5ae9',
+  green_light: '#76e8ad',
+  green_0: '#35d48d',
+  green_dark: '#1bbf83',
+  red_light: '#ff8e89',
+  red_0: '#ff5d5d',
+  red_dark: '#f24147',
+  gray_0: '#f8fafb',
+  gray_1: '#f1f5f5',
+  gray_2: '#eaeeef',
+  gray_3: '#e1e4e6',
+  gray_4: '#ced3d6',
+  gray_5: '#a9afb3',
+  gray_6: '#878d91',
+  gray_7: '#4d5256',
+  gray_8: '#363a3c',
+  gray_9: '#292a2b',
+};
+
 const theme = {
-  colors: {
-    blue_light: '#87b1f3',
-    blue_0: '#4c80f1',
-    blue_dark: '#2c5ae9',
-    green_light: '#76e8ad',
-    green_0: '#35d48d',
-    green_dark: '#1bbf83',
-    red_light: '#ff8e89',
-    red_0: '#ff5d5d',
-    red_dark: '#f24147',
-    gray_0: '#f8fafb',
-    gray_1: '#f1f5f5',
-    gray_2: '#eaeeef',
-    gray_3: '#e1e4e6',
-    gray_4: '#ced3d6',
-    gray_5: '#a9afb3',
-    gray_6: '#878d91',
-    gray_7: '#4d5256',
-    gray_8: '#363a3c',
-    gray_9: '#292a2b',
-  },
+  colors,
 };
 
 export default theme;

--- a/styles/theme.ts
+++ b/styles/theme.ts
@@ -18,7 +18,7 @@ const colors = {
   gray_7: '#4d5256',
   gray_8: '#363a3c',
   gray_9: '#292a2b',
-};
+} as const;
 
 const theme = {
   colors,


### PR DESCRIPTION
## 📌 전반적인 개발 내용

typescript에서 emotion의 theme props를 이용하기 위한 emotion.d.ts 추가 #28 

<br>

## 💻 변경 내용

- emotion.d.ts 파일 생성
- theme 하위에 위치한 colors를 분리

<br>

## ✅ 관심 리뷰

- 스타일과 깊게 연관된 타입 정의라 types 폴더 하위에 위치하지 않고 styled 내부에 만들었습니다. 타입 정의란 측면을 기준으로 types 폴더 하위에 위치시키는 게 좋은지, styles과 뗄 수 없는 성질을 가졌다는 성질 기준으로 styles 폴더 내부에 위치시키는 지 좋을지 @Jisu00 와 @ahn0min 님 생각이 궁금합니다
- theme.ts 내부에 colors 뿐만 아니라 font size나 device type 같은 새로운 정보가 추가될 것을 고려해 types 내부에 직접적으로 위치해 있던 colors를 const로 뺐습니다
