### PR TITLE
[FIX] yarn 대신 설치된 cmdtest 제거 후 yarn 설치

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -26,6 +26,16 @@ export NVM_DIR="$HOME/.nvm"
 [ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh"  # This loads nvm
 [ -s "$NVM_DIR/bash_completion" ] && \. "$NVM_DIR/bash_completion"  # This loads nvm bash_completion
 
+# 임시 작업
+# 현재 ubuntu 서버에 접속할 수 있는 키가 없어 임시적으로 작업
+
+sudo apt remove cmdtest
+sudo apt remove yarn
+curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | sudo apt-key add -
+echo "deb https://dl.yarnpkg.com/debian/ stable main" | sudo tee /etc/apt/sources.list.d/yarn.list
+sudo apt-get update
+sudo apt-get install yarn -y
+
 yarn install
 
-nuhup yarn start >> $REPOSITORY/nohup.out 2>&1 &
+nohup yarn start >> $REPOSITORY/nohup.out 2>&1 &


### PR DESCRIPTION
## 📌 전반적인 개발 내용

- AWS 배포시 yarn start ERROR 해결

<br>

## 💻 변경 내용

- deploy.sh에서 cmdtest 제거 & yarn 재설치 코드 추가


<br>

## ✅ 관심 리뷰

- 비슷한 에러를 해결한 경험이 있다면 공유 부탁드립니다!

close #44 