### PR TITLE
[FIX] SignUpForm errors 타입 에러 해결

### DIFF
--- a/components/signup/SignUpForm.tsx
+++ b/components/signup/SignUpForm.tsx
@@ -1,6 +1,6 @@
 import { ChangeEvent, FormEvent, MouseEvent, useEffect } from 'react';
 
-import useForm from 'hooks/useForm';
+import useForm, { ErrorType } from 'hooks/useForm';
 import { usersAPI } from 'api/users';
 import { emailsAPI } from 'api/emails';
 import { UserFormType } from 'typings/account';
@@ -83,7 +83,7 @@ const SignUpForm = () => {
 
 interface SignUpFormViewProps {
   values: UserFormType;
-  errors?: UserFormType;
+  errors?: ErrorType;
   disabled: boolean;
   onValid: () => void;
   sendEmailVerifyCode: () => void;

--- a/hooks/useForm.tsx
+++ b/hooks/useForm.tsx
@@ -7,7 +7,7 @@ import {
   useState,
 } from 'react';
 
-interface ErrorType {
+export interface ErrorType {
   [errorName: string]: string;
 }
 


### PR DESCRIPTION
## 📌 전반적인 개발 내용

SignUpForm errors 타입 에러 해결

<br>

## 💻 변경 내용

- `useForm`의 `ErrorType` export
- 위 타입을 errors의 타입으로 수정

<br>

## ✅ 관심 리뷰

- 어떤 부분에 대해 집중적으로 리뷰가 필요한지 설명해주세요.
