### PR TITLE
[FIX] QualitySectionProps interface 내부 string[] 타입 추가

### DIFF
--- a/components/review/ReviewWriteModal/QualitySection/@index.tsx
+++ b/components/review/ReviewWriteModal/QualitySection/@index.tsx
@@ -12,7 +12,7 @@ import SurveyBox from './SurveyBox';
 interface QualitySectionProps {
   values: ReviewType;
   data?: ReviewResponseType;
-  setValue: (name: string, value: number | File[]) => void;
+  setValue: (name: string, value: number | string[] | File[]) => void;
   handleChange: (e: ChangeEvent<HTMLTextAreaElement>) => void;
 }
 


### PR DESCRIPTION
## 📌 전반적인 개발 내용

 QualitySectionProps interface 내부 string[] 타입 추가

<br>

## 💻 변경 내용

변경 전
```
  setValue: (name: string, value: number | File[]) => void;
```

변경 후
```
  setValue: (name: string, value: number | string[] | File[]) => void;

```

<br>


