### PR TITLE
[FEATURE] 이메일 인증 번호 중복 발급 제한 구현

### DIFF
--- a/api/emails.ts
+++ b/api/emails.ts
@@ -4,9 +4,10 @@ import { ERROR_MESSAGE, SUCCESS_MESSAGE } from 'constants/account';
 const url = '/emails';
 
 export const emailsAPI = {
-  verifyEmail: (email: string) => {
+  verifyEmail: async (email: string) => {
     const params = { accountId: email };
-    authApi
+
+    return await authApi
       .get(`${url}/verify`, { params })
       .then(({ status }) => {
         switch (status) {
@@ -14,9 +15,13 @@ export const emailsAPI = {
             alert(SUCCESS_MESSAGE.SIGN_UP.VERIFY_CODE);
             break;
         }
+
+        return { ok: true };
       })
       .catch(() => {
         alert(ERROR_MESSAGE.SIGN_UP.VERIFY_CODE);
+
+        return { ok: false };
       });
   },
 };

--- a/api/emails.ts
+++ b/api/emails.ts
@@ -1,16 +1,22 @@
 import { authApi } from 'api/instance';
+import { ERROR_MESSAGE, SUCCESS_MESSAGE } from 'constants/account';
 
 const url = '/emails';
 
 export const emailsAPI = {
   verifyEmail: (email: string) => {
     const params = { accountId: email };
-    authApi.get(`${url}/verify`, { params }).then(({ status }) => {
-      switch (status) {
-        case 200:
-          alert('인증 번호를 전송하였습니다.');
-          break;
-      }
-    });
+    authApi
+      .get(`${url}/verify`, { params })
+      .then(({ status }) => {
+        switch (status) {
+          case 200:
+            alert(SUCCESS_MESSAGE.SIGN_UP.VERIFY_CODE);
+            break;
+        }
+      })
+      .catch(() => {
+        alert(ERROR_MESSAGE.SIGN_UP.VERIFY_CODE);
+      });
   },
 };

--- a/api/users.ts
+++ b/api/users.ts
@@ -21,7 +21,6 @@ export const usersAPI = {
   },
   signUp: async (values: UserFormType) => {
     const body: SignUpParams = {
-      nickname: 'test1234',
       accountId: values.accountId,
       accountPw: values.accountPw,
       birthDate: values.birthDate,
@@ -34,9 +33,9 @@ export const usersAPI = {
       .post(`${url}/register`, body)
       .then((res) => res.data)
       .catch(({ response }) => {
-        switch (response.status) {
+        switch (response?.status) {
           case 401:
-            alert(response.data[0].message);
+            alert(response?.data[0]?.message);
             break;
         }
       });

--- a/components/signup/SignUpForm.tsx
+++ b/components/signup/SignUpForm.tsx
@@ -68,8 +68,10 @@ const SignUpForm = () => {
 
     if (signUpResult) {
       doSignIn(signUpResult.accessToken);
-      window.location.replace('/');
+      return window.location.replace('/');
     }
+
+    setCodeIssuanceStatus('NOT_ISSUED');
   };
 
   useEffect(() => {

--- a/components/signup/SignUpForm.tsx
+++ b/components/signup/SignUpForm.tsx
@@ -25,6 +25,7 @@ const SignUpForm = () => {
     values,
     errors,
     isSubmitable,
+    setValue,
     setErrors,
     handleChange,
     handleSubmit,
@@ -76,7 +77,10 @@ const SignUpForm = () => {
     setErrors(newErrors);
   }, [values, setErrors]);
 
-  useEffect(() => setCodeIssuanceStatus('NOT_ISSUED'), [accountId]);
+  useEffect(() => {
+    setCodeIssuanceStatus('NOT_ISSUED');
+    setValue('verifyCode', '');
+  }, [accountId, setValue]);
 
   const props = {
     values,

--- a/components/signup/SignUpForm.tsx
+++ b/components/signup/SignUpForm.tsx
@@ -1,9 +1,9 @@
-import { ChangeEvent, FormEvent, MouseEvent, useEffect } from 'react';
+import { ChangeEvent, FormEvent, MouseEvent, useState, useEffect } from 'react';
 
 import useForm, { ErrorType } from 'hooks/useForm';
 import { usersAPI } from 'api/users';
 import { emailsAPI } from 'api/emails';
-import { UserFormType } from 'typings/account';
+import { UserFormType, CodeIssuanceType } from 'typings/account';
 import {
   validateEmail,
   validatePassword,
@@ -29,10 +29,18 @@ const SignUpForm = () => {
     handleChange,
     handleSubmit,
   } = useForm({ ...DEFAULT_SIGN_UP_FORM });
+  const { accountId } = values;
+  const [codeIssuanceStatus, setCodeIssuanceStatus] =
+    useState<CodeIssuanceType>('NOT_ISSUED');
 
-  const sendEmailVerifyCode = () => {
+  const sendEmailVerifyCode = async () => {
     if (errors?.accountId) return alert(ERROR_MESSAGE.SIGN_UP.EMAIL);
-    emailsAPI.verifyEmail(values.accountId);
+    setCodeIssuanceStatus('IN_PROGRESS');
+    const result = await emailsAPI.verifyEmail(values.accountId);
+
+    result.ok
+      ? setCodeIssuanceStatus('COMPLETE')
+      : setCodeIssuanceStatus('NOT_ISSUED');
   };
 
   const signUpValidate = (values: UserFormType) => {
@@ -68,10 +76,14 @@ const SignUpForm = () => {
     setErrors(newErrors);
   }, [values, setErrors]);
 
+  useEffect(() => setCodeIssuanceStatus('NOT_ISSUED'), [accountId]);
+
   const props = {
     values,
     errors,
     disabled: !isSubmitable,
+    isCodeIssuable: codeIssuanceStatus === 'NOT_ISSUED',
+    isCodeIssued: codeIssuanceStatus === 'COMPLETE',
     onValid,
     handleChange,
     handleSubmit,
@@ -85,6 +97,8 @@ interface SignUpFormViewProps {
   values: UserFormType;
   errors?: ErrorType;
   disabled: boolean;
+  isCodeIssuable: boolean;
+  isCodeIssued: boolean;
   onValid: () => void;
   sendEmailVerifyCode: () => void;
   handleChange: (
@@ -97,6 +111,8 @@ const SignUpFormView = ({
   values,
   errors,
   disabled,
+  isCodeIssuable,
+  isCodeIssued,
   sendEmailVerifyCode,
   handleChange,
   ...rest
@@ -114,17 +130,22 @@ const SignUpFormView = ({
                 handleChange={handleChange}
               />
               <S.VerifyButtonWrap>
-                <S.Button color="black" handleClick={sendEmailVerifyCode}>
+                <S.Button
+                  disabled={!isCodeIssuable}
+                  color="black"
+                  handleClick={sendEmailVerifyCode}
+                >
                   인증번호 받기
                 </S.Button>
               </S.VerifyButtonWrap>
             </S.EmailBox>
-
-            <S.Input
-              name={SIGN_UP_FORM_NAMES.VERIFY_CODE}
-              placeholder="인증번호 입력"
-              handleChange={handleChange}
-            />
+            {isCodeIssued && (
+              <S.Input
+                name={SIGN_UP_FORM_NAMES.VERIFY_CODE}
+                placeholder="인증번호 입력"
+                handleChange={handleChange}
+              />
+            )}
             {values?.accountId && <S.WarnText>{errors?.accountId}</S.WarnText>}
             {/* <S.EmailInputBox>
           <S.Input placeholder="이메일" />

--- a/constants/account.ts
+++ b/constants/account.ts
@@ -1,19 +1,20 @@
 import { UserFormType } from 'typings/account';
 
-const SIGN_UP = {
-  EMAIL: '이메일 형식에 맞지 않습니다. 다시 입력해주세요.',
-  TEL: '전화번호는 숫자만 입력해주세요.',
-  PASSWORD:
-    '영문자, 숫자, 특수문자가 조합된 6자리 이상의 비밀번호를 입력해주세요.',
-  PASSWORDCHECK: '비밀번호가 일치하지 않습니다. 다시 입력해주세요.',
+export const ERROR_MESSAGE = {
+  SIGN_UP: {
+    EMAIL: '이메일 형식에 맞지 않습니다. 다시 입력해주세요.',
+    TEL: '전화번호는 숫자만 입력해주세요.',
+    PASSWORD:
+      '영문자, 숫자, 특수문자가 조합된 6자리 이상의 비밀번호를 입력해주세요.',
+    PASSWORDCHECK: '비밀번호가 일치하지 않습니다. 다시 입력해주세요.',
+    VERIFY_CODE: '인증 번호 전송에 실패하였습니다.',
+  },
+  SIGN_IN:
+    '등록되지 않은 아이디이거나 아이디 또는 비밀번호를 잘못 입력했습니다.',
 };
 
-const SIGN_IN =
-  '등록되지 않은 아이디이거나 아이디 또는 비밀번호를 잘못 입력했습니다.';
-
-export const ERROR_MESSAGE = {
-  SIGN_UP,
-  SIGN_IN,
+export const SUCCESS_MESSAGE = {
+  SIGN_UP: { VERIFY_CODE: '인증 번호를 전송하였습니다.' },
 };
 
 export const DEFAULT_SIGN_UP_FORM: UserFormType = {

--- a/typings/account.ts
+++ b/typings/account.ts
@@ -8,6 +8,8 @@ export interface UserFormType {
   verifyCode?: string;
 }
 
+export type CodeIssuanceType = 'NOT_ISSUED' | 'IN_PROGRESS' | 'COMPLETE';
+
 export interface SignUpParams {
   accountId: string;
   accountPw: string;


### PR DESCRIPTION
## 📌 전반적인 개발 내용

이메일 인증 번호 발급 시, 중복으로 요청이 가는 상황을 제한하도록 구현

<br>

## 💻 변경 내용

- 요청 중 & 발급 완료일 경우, 인증 번호 발급 버튼 비활성화
- 발급 완료일 경우, 이메일 인증 번호 입력 Input 활성화
- 이후 이메일 변경 시, 다시 초기 상태로 전환

<br>

## ✅ 관심 리뷰

- 어떤 부분에 대해 집중적으로 리뷰가 필요한지 설명해주세요.
