### PR TITLE
[CHORE] Chromatic에서 ui-test를 실행하지 않도록 설정을 변경

### DIFF
--- a/components/Project/common/ProjectPageButton.stories.tsx
+++ b/components/Project/common/ProjectPageButton.stories.tsx
@@ -7,5 +7,5 @@ export default {
 } as Meta;
 
 export const primary: StoryFn<typeof ProjectPageButton> = () => (
-  <ProjectPageButton>텍스트</ProjectPageButton>
+  <ProjectPageButton>텍스트변경</ProjectPageButton>
 );

--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
     "start": "next start",
     "lint": "next lint",
     "storybook": "storybook dev -p 6006",
-    "build-storybook": "storybook build --no-scripts",
+    "test": "echo 'No tests specified'",
+    "build-storybook": "storybook build",
     "chromatic": "chromatic --exit-zero-on-changes"
   },
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "start": "next start",
     "lint": "next lint",
     "storybook": "storybook dev -p 6006",
-    "build-storybook": "storybook build",
+    "build-storybook": "storybook build --no-scripts",
     "chromatic": "chromatic --exit-zero-on-changes"
   },
   "dependencies": {


### PR DESCRIPTION
## 📌 전반적인 개발 내용
`yarn storybook build`를 하게 되면 내부적으로 `yarn test`를 진행하는데 이 과정에서 우리가 정의하지 않은 PR을 생성했을 때 2번째 3번째 라인에 들어갔던 ui test 등을 진행하였음

package.json에서`yarn test`를 ui test 가 아닌  'No tests specified"라는 문구를 출력하는걸로  오버라이딩해서 해결하였음

*"No tests specified" __대신 들어갈 좋은 문구가 있으면 추천해주세요__*



<br>

## 💻 변경 내용
- package.json 파일에서 "test" scripts 변경

<br>

## ✅ 관심 리뷰

- 어떤 부분에 대해 집중적으로 리뷰가 필요한지 설명해주세요.
