### PR TITLE
[FEATURE] social follow and unfollow를 처리하는 hook 생성

### DIFF
--- a/api/instance.ts
+++ b/api/instance.ts
@@ -1,7 +1,7 @@
 import axios from 'axios';
 
 import { verifyToken, verifyTokenErrorHandler } from 'utils/auth';
-import { errorHandler } from 'utils/errorHandler';
+import { redirectErrorHandler } from 'utils/errorHandler';
 
 export const api = axios.create({
   baseURL: process.env.NEXT_PUBLIC_SERVER_URL,
@@ -16,4 +16,4 @@ export const authApi = axios.create({
 export const oauthApi = axios.create();
 
 api.interceptors.request.use(verifyToken, verifyTokenErrorHandler);
-api.interceptors.response.use((response) => response, errorHandler);
+api.interceptors.response.use((response) => response, redirectErrorHandler);

--- a/api/sns.ts
+++ b/api/sns.ts
@@ -6,4 +6,13 @@ export const snsAPI = {
   createReview: async (formData: FormData) => {
     return await api.post(`${SNS_URL}/reviews`, formData);
   },
+  follow: (body: FollowAndUnFollowRequestBody) =>
+    api.post(`${SNS_URL}/request-follow`, body),
+
+  unfollow: (body: FollowAndUnFollowRequestBody) =>
+    api.post(`${SNS_URL}/request-unfollow`, body),
+};
+
+type FollowAndUnFollowRequestBody = {
+  targetUserAccountId: string;
 };

--- a/hooks/useFollowAndUnFollow.tsx
+++ b/hooks/useFollowAndUnFollow.tsx
@@ -1,0 +1,28 @@
+import { useMutation } from '@tanstack/react-query';
+import type { AxiosError } from 'axios';
+
+import { snsAPI } from 'api/sns';
+import { alertErrorHandler } from 'utils/errorHandler';
+import type { ResponseError } from 'typings/error';
+
+const useFollowAndUnFollow = (targetUserAccountId: string) => {
+  const { mutate: follow } = useMutation(
+    () => snsAPI.follow({ targetUserAccountId }),
+    {
+      onError: (err: AxiosError<ResponseError>) => alertErrorHandler(err),
+    }
+  );
+  const { mutate: unfollow } = useMutation(
+    () => snsAPI.unfollow({ targetUserAccountId }),
+    {
+      onError: (err: AxiosError<ResponseError>) => alertErrorHandler(err),
+    }
+  );
+
+  return {
+    follow: () => follow(),
+    unfollow: () => unfollow(),
+  };
+};
+
+export default useFollowAndUnFollow;

--- a/typings/error.ts
+++ b/typings/error.ts
@@ -1,7 +1,7 @@
-type ResponseArror = {
-  errorType: string;
-  fieldName: string;
-  message: string;
-};
+export interface ResponseErrorDto {
+  errorType: 'FollowAlreadyExistsException';
+  fieldName: 'targetUserAccountId';
+  message: '이미 수행된 팔로우 요청입니다';
+}
 
-export default ResponseArror;
+export type ResponseError = ResponseErrorDto[];

--- a/typings/error.ts
+++ b/typings/error.ts
@@ -1,7 +1,7 @@
 export interface ResponseErrorDto {
-  errorType: 'FollowAlreadyExistsException';
-  fieldName: 'targetUserAccountId';
-  message: '이미 수행된 팔로우 요청입니다';
+  errorType: string;
+  fieldName: string;
+  message: string;
 }
 
 export type ResponseError = ResponseErrorDto[];

--- a/utils/errorHandler.ts
+++ b/utils/errorHandler.ts
@@ -1,9 +1,11 @@
 import { AxiosError } from 'axios';
+
 import { windowNavigate } from 'utils/windowNavigate';
+import type { ResponseError } from 'typings/error';
 
 const SIGN_IN = 'sign-in';
 
-export function errorHandler(err: AxiosError<any, any>) {
+export function redirectErrorHandler(err: AxiosError<ResponseError, any>) {
   const REDIRECT_URL = `${window?.location.origin}/${SIGN_IN}`;
   const status = err.response?.status;
 
@@ -19,8 +21,18 @@ export function errorHandler(err: AxiosError<any, any>) {
     alert('권한이 없어요.');
     return windowNavigate(REDIRECT_URL);
   }
+
+  throw err;
+}
+
+export function alertErrorHandler(err: AxiosError<ResponseError, any>) {
+  const status = err.response?.status;
+
   if (status === 415) {
     console.warn('header의 content-type을 확인해주세요');
-    return alert('개발자에게 문의해 주세요. reviewTwit@google.com');
+    return alert(`${status} 개발자에게 문의해 주세요. reviewTwit@google.com`);
   }
+
+  const message = err.response?.data[0].message;
+  alert(message);
 }


### PR DESCRIPTION
## 📌 전반적인 개발 내용
소셜 팔로우와 언팔로우 api를 연동하는 작업진행

버튼 등에 기능을 입히는 작업을 진행하지 않았습니다. 
<br>

## 💻 변경 내용
- error 타입 변경
- axios.interceptor.response 에러 핸들러 함수 변경 (조건문에 걸리지 않는 status code의 경우 에러전파가 끝나는 이슈가 발생했기 때문입니다.)
- snsAPI 추가 (follow, unfollow)
- 팔로우, 언팔로우 기능함수를 반환하는 `useFollowAndUnFollow` hook 추가

<br>

## ✅ 관심 리뷰
And라는 접속사를 사용하는것을 선호하지 않지만 follow와 unfollow는 밀접한 관련이 있다고 판단되어 이 둘을 하나의 hook에서 처리하도록 구현하였습니다.
