### PR TITLE
[FEATURE] 404와 Private URL 분리

### DIFF
--- a/components/common/PrivateRoute.tsx
+++ b/components/common/PrivateRoute.tsx
@@ -13,6 +13,7 @@ const PUBLIC_URLS = [
   '/social/home',
   '/socual/user',
   '/social/user/[nickname]',
+  '/404',
 ];
 
 const PrivateRoute = ({


### PR DESCRIPTION
## 📌 전반적인 개발 내용

404와 Private URL 분리

<br>

## 💻 변경 내용

의외로 간단하게 `PUBLIC_URLS`에 `/404`를 추가해주니 존재하지 않는 모든 페이지에 접근했을 경우 404 컴포넌트를 띄워줄 수 있었습니다.

<br>

## ✅ 관심 리뷰

- 어떤 부분에 대해 집중적으로 리뷰가 필요한지 설명해주세요.
