### PR TITLE
[FEAT] 프로젝트 install guide 페이지 개선

### DIFF
--- a/components/Project/Create/ProjectCreateLayout.tsx
+++ b/components/Project/Create/ProjectCreateLayout.tsx
@@ -6,12 +6,12 @@ import { ProjectCreateContent } from 'components/Project/Create/ProjectCreateCon
 import { ProjectCreateTabItem } from 'components/Project/Create/ProjectCreateTapItem';
 import { ProjectPageButton } from 'components/Project/common/ProjectPageButton';
 
-type ProjectPathnames = 'create' | 'plans' | 'platform';
+type ProjectPathnames = 'create' | 'plans' | 'install';
 
 const SIDEBAR_MENUS: Record<ProjectPathnames, string> = {
   create: '등록정보 입력',
   plans: '플랜선택',
-  platform: '설치 플랫폼 선택',
+  install: '설치 플랫폼 선택',
 };
 
 interface ProjectCreateLayoutProps {

--- a/components/Project/Management/ProjectCard.tsx
+++ b/components/Project/Management/ProjectCard.tsx
@@ -1,5 +1,6 @@
 import styled from '@emotion/styled';
 import { useState } from 'react';
+import Link from 'next/link';
 
 import {
   ProjectCardCommon,
@@ -7,6 +8,7 @@ import {
 } from 'components/Project/Management/ProjectCardCommon';
 import { ProjectDto } from 'typings/project';
 import { GetProjectsResponseData } from 'api/projects';
+import Button from 'components/common/Button';
 
 interface ProjectCardProps {
   project: GetProjectsResponseData;
@@ -74,6 +76,33 @@ export const ProjectCardView = ({
               <S.ContentItem>리뷰 : {review}</S.ContentItem>
             </S.SubTitle>
             <S.Description>{description}</S.Description>
+
+            {
+              // TODO: 임시
+            }
+            <div style={{ display: 'flex', justifyContent: 'center' }}>
+              <Button>
+                <Link
+                  href={{
+                    pathname: '/project/install',
+                    query: { projectName: name },
+                  }}
+                  style={{ color: 'black' }}
+                >
+                  설치가이드
+                </Link>
+              </Button>
+              <Button>
+                <Link href={'/project/install'} style={{ color: 'black' }}>
+                  수정
+                </Link>
+              </Button>
+              <Button>
+                <Link href={'/project/install'} style={{ color: 'black' }}>
+                  설정
+                </Link>
+              </Button>
+            </div>
           </S.ContentWrap>
         )}
       </S.BehindContent>

--- a/pages/project/install/index.tsx
+++ b/pages/project/install/index.tsx
@@ -11,18 +11,6 @@ const PLATFORMS = [
     name: 'React',
     Icon: ReactIcon,
   },
-  {
-    name: 'Jekyll',
-    Icon: ReactIcon,
-  },
-  {
-    name: 'Wordpress',
-    Icon: ReactIcon,
-  },
-  {
-    name: 'Blogger',
-    Icon: ReactIcon,
-  },
 ];
 
 const InstallPage = () => {

--- a/pages/project/install/index.tsx
+++ b/pages/project/install/index.tsx
@@ -1,8 +1,10 @@
 import styled from '@emotion/styled';
+import Link from 'next/link';
+import { useRouter } from 'next/router';
+
 import { ProjectPageLayout } from 'components/Project/common/ProjectPageLayout';
 import { ProjectCreateLayout } from 'components/Project/Create/ProjectCreateLayout';
 import { PROJECT_TITLE } from 'constants/project';
-import Link from 'next/link';
 
 import ReactIcon from 'public/icons/react.svg';
 
@@ -14,6 +16,9 @@ const PLATFORMS = [
 ];
 
 const InstallPage = () => {
+  const router = useRouter();
+  const query = router.query as { projectName: string };
+
   return (
     <ProjectPageLayout>
       <ProjectCreateLayout title={PROJECT_TITLE}>
@@ -21,7 +26,7 @@ const InstallPage = () => {
           <S.ProjectSelectPlatformList>
             {PLATFORMS.map(({ name, Icon }) => (
               <Link
-                href={{ pathname: `install/${name}` }}
+                href={{ pathname: `install/${name}`, query }}
                 key={name}
                 style={{ textDecoration: 'none', color: '#3D3D3D' }}
               >


### PR DESCRIPTION
## 📌 전반적인 개발 내용
프로젝트 생성, 플랜선택, 인스톨 가이드 페이지의 전체 flow에 맞게 이동되도록 개선하였습니다.

<br>

## 💻 변경 내용
- 프로젝트 카드에서 해당 프로젝트의 수정, 설치가이드 페이지로 연결되는 버튼 추가
- style: 프로젝트 생성 사이드바 focus 효과 적용되도록 object key 값 변경

<br>

## ✅ 관심 리뷰

- 어떤 부분에 대해 집중적으로 리뷰가 필요한지 설명해주세요.
