### PR TITLE
[FIX] 팔로워 관리 페이지에서 사용자 클릭 시 사용자 프로필로 이동

### DIFF
--- a/components/social/common/SocialCard.styles.ts
+++ b/components/social/common/SocialCard.styles.ts
@@ -25,6 +25,8 @@ const userBox = styled.div`
 
   width: 175px;
   height: 72px;
+
+  cursor: pointer;
 `;
 
 const ImageBox = styled.div`

--- a/components/social/common/SocialCard.tsx
+++ b/components/social/common/SocialCard.tsx
@@ -4,6 +4,7 @@ import * as S from './SocialCard.styles';
 import { formattedProfileImageUrl } from 'utils/format';
 
 import SocialFollowAndUnfollowButton from 'components/social/profile/SocialFollowAndUnfollowButton';
+import { useRouter } from 'next/router';
 
 interface SocialCardProps {
   imageUrl: string | null;
@@ -12,9 +13,15 @@ interface SocialCardProps {
 }
 
 const SocialCard = ({ imageUrl, nickname, role }: SocialCardProps) => {
+  const router = useRouter();
+
+  const onUserClick = () => {
+    router.push(`/social/user/${nickname}`);
+  };
+
   return (
     <S.Container>
-      <S.userBox>
+      <S.userBox onClick={onUserClick}>
         <S.ImageBox>
           <Image
             src={formattedProfileImageUrl(imageUrl)}


### PR DESCRIPTION
## 📌 전반적인 개발 내용

- 팔로워 관리 페이지에서 사용자 클릭 시 사용자 프로필로 이동
<br>

## 💻 변경 내용

- 팔로워 관리 페이지에서 사용자 클릭 시 사용자 프로필로 이동
- cursor style pointer로 변경

<br>

