### PR TITLE
[REFACTOR] 쿼리키를 객체로 관리하도록 변경

### DIFF
--- a/components/Project/Management/ProjectManagementSection.tsx
+++ b/components/Project/Management/ProjectManagementSection.tsx
@@ -8,6 +8,7 @@ import { Styles } from 'components/Project/Management/ProjectCardCommon';
 import { CreateProjectCard } from 'components/Project/Management/CreateProjectCard';
 
 import { GetProjectsResponseData, projectsAPI } from 'api/projects';
+import { queryKey } from 'hooks/queries';
 
 interface ProjectManagementSectionViewProps {
   children?: ReactNode;
@@ -20,7 +21,7 @@ const CREATE_PROJECT_STYLES: Styles = {
 };
 
 export const ProjectManagementSection = () => {
-  const { data } = useQuery(['projectManagement'], projectsAPI.get, {
+  const { data } = useQuery(queryKey.prodjects(), projectsAPI.get, {
     retry: false,
   });
 

--- a/components/ShoppingMallReview/Reviews.tsx
+++ b/components/ShoppingMallReview/Reviews.tsx
@@ -13,6 +13,7 @@ import { RegisterProjectParams } from 'typings/register';
 import { replaceUrlProtocool } from 'constants/regExp';
 import { useQueryClient } from '@tanstack/react-query';
 import { AxiosResponse } from 'axios';
+import { queryKey } from 'hooks/queries';
 
 interface ReviewsProps {
   projectName: string;
@@ -35,7 +36,7 @@ const Reviews = ({ projectName, productURL, title, image }: ReviewsProps) => {
 
   const cachedData = cache.getQueryData<
     AxiosResponse<ShoppingMallReviewDetail[]>
-  >(['useGetShoppingMallReviewList', productURL, 'NEWEST']);
+  >(queryKey.useCachedGetShoppingMallReviewList(productURL));
 
   if (shoppingmallReviewList?.data) {
     return (

--- a/components/social/Follower/index.tsx
+++ b/components/social/Follower/index.tsx
@@ -7,6 +7,7 @@ import useUserProfile from 'hooks/queries/users';
 import { FOLLOW_BUTTON } from 'constants/social';
 import styled from '@emotion/styled';
 import { useQueryClient } from '@tanstack/react-query';
+import { queryKey } from 'hooks/queries';
 
 type FollowButton = (typeof FOLLOW_BUTTON)[keyof typeof FOLLOW_BUTTON];
 
@@ -36,8 +37,8 @@ const FollowerSection = () => {
   const queryClient = useQueryClient();
   useEffect(() => {
     userList === followerList
-      ? queryClient.invalidateQueries(['useGetFollowingList'])
-      : queryClient.invalidateQueries(['useGetFollowerList']);
+      ? queryClient.invalidateQueries(queryKey.followingList())
+      : queryClient.invalidateQueries(queryKey.followerList());
   }, [
     followerList,
     followerListInfiniteQuery,

--- a/components/social/feed/SideBar/TrendyProductsContent.tsx
+++ b/components/social/feed/SideBar/TrendyProductsContent.tsx
@@ -6,10 +6,12 @@ import { ProductType } from 'typings/reviews';
 
 import Card from '../Card';
 import Product from './Product';
+import { queryKey } from 'hooks/queries';
 
 const TrendyProductsContent = () => {
-  const { data: products } = useQuery<ProductType[]>(['trend'], () =>
-    snsAPI.getTrendyProducts()
+  const { data: products } = useQuery<ProductType[]>(
+    queryKey.socialtTrendProducts(),
+    () => snsAPI.getTrendyProducts()
   );
 
   return (

--- a/components/social/review/SearchBox.tsx
+++ b/components/social/review/SearchBox.tsx
@@ -15,6 +15,7 @@ import styled from '@emotion/styled';
 import SearchBar from './SearchBar';
 import RatingBox from 'components/review/common/RatingBox';
 import itemsAPI from 'api/items';
+import { queryKey } from 'hooks/queries';
 
 interface SearchBoxProps {
   productName?: string;
@@ -25,7 +26,7 @@ const SearchBox = ({ productName, setValue }: SearchBoxProps) => {
   const [searchValue, setSearchValue] = useState<string>('');
   const [isSearchFocused, setIsSearchFocused] = useState<boolean>(false);
   const { data: searchResult } = useQuery<ProductSearchResultType[]>(
-    ['searchProductName', searchValue],
+    queryKey.searchProductName(searchValue),
     () => itemsAPI.searchProductName(searchValue),
     {
       enabled: !!searchValue,
@@ -34,7 +35,7 @@ const SearchBox = ({ productName, setValue }: SearchBoxProps) => {
   );
   const { data: productInfo, isFetching: isProductInfoFetching } =
     useQuery<ProductInfoType | null>(
-      ['productInfo', productName],
+      queryKey.productInfo(productName),
       () => (productName ? itemsAPI.getProductInfo(productName) : null),
       {
         enabled: !!productName,

--- a/hooks/queries/index.ts
+++ b/hooks/queries/index.ts
@@ -9,6 +9,7 @@ type ProductName = string | undefined;
 type SearchValue = string;
 
 export const queryKey = {
+  myProfile: (isLogin: boolean) => ['myProfile', isLogin],
   /*
 
     shoppingMall
@@ -36,7 +37,7 @@ export const queryKey = {
 
   */
 
-  socialProfile: () => ['socialProfile'],
+  socialUserProfile: () => ['socialProfile'],
 
   // social follow
   followingList: () => ['followingList'],
@@ -45,6 +46,7 @@ export const queryKey = {
   followerSuggestion: () => ['followSuggestion'],
 
   // social home
+  socialtTrendProducts: () => ['socialTrendProucts'],
   socialInfiniteFeed: () => ['useSocialInfiniteFeed'],
   userReviews: (nickname: Nickname) => ['userReviews', nickname],
   userOneReview: (reviewId: ReviewId) => ['userOneReview', reviewId],

--- a/hooks/queries/index.ts
+++ b/hooks/queries/index.ts
@@ -1,0 +1,83 @@
+type ProductURL = string;
+type SortOption = 'BEST' | 'NEWEST';
+type ReviewId = number;
+type Nickname = string;
+type CommentId = number;
+type SelectedUser = string;
+
+type ProductName = string | undefined;
+type SearchValue = string;
+
+export const queryKey = {
+  /*
+
+    shoppingMall
+
+  */
+
+  useCachedGetShoppingMallReviewList: (productURL: ProductURL) => [
+    'useCachedGetShoppingMallReviewList',
+    productURL,
+    'NEWEST',
+  ],
+  shoppingMallReviewInfo: (productURL: ProductURL) => [
+    'shoppingMallReviewInfo',
+    productURL,
+  ],
+  shoppingMallReviewList: (productURL: ProductURL, sort: SortOption) => [
+    'shoppingMallReviewList',
+    productURL,
+    sort,
+  ],
+
+  /*
+
+    social
+
+  */
+
+  socialProfile: () => ['socialProfile'],
+
+  // social follow
+  followingList: () => ['followingList'],
+  followingDictionary: () => ['followingDictionary'],
+  followerList: () => ['followerList'],
+  followerSuggestion: () => ['followSuggestion'],
+
+  // social home
+  socialInfiniteFeed: () => ['useSocialInfiniteFeed'],
+  userReviews: (nickname: Nickname) => ['userReviews', nickname],
+  userOneReview: (reviewId: ReviewId) => ['userOneReview', reviewId],
+  review: (reviewId: ReviewId) => ['review', reviewId],
+  reviewComments: (reviewId: ReviewId) => ['review', 'comments', reviewId],
+  reviewComment: (reviewId: ReviewId, commentId: CommentId) => [
+    'review',
+    'comment',
+    reviewId,
+    commentId,
+  ],
+  infiniteScrapList: () => ['useGetInfiniteScrapList'],
+  recentUpdatedUser: () => ['recentUpdatedUser'],
+  userInfiniteFeed: (selectedUser: SelectedUser) => [
+    'useGetInfiniteFeed',
+    selectedUser,
+  ],
+
+  socialMyReviews: (nickname: Nickname) => ['socialMyReviews', nickname],
+
+  // social product review
+
+  productInfo: (productName: ProductName) => ['productInfo', productName],
+  searchProductName: (searchValue: SearchValue) => [
+    'searchProductName',
+    searchValue,
+  ],
+
+  /*
+  
+  project
+ 
+  */
+
+  prodjects: () => ['projects'],
+};

--- a/hooks/queries/reviews.ts
+++ b/hooks/queries/reviews.ts
@@ -1,9 +1,10 @@
 import { useQuery } from '@tanstack/react-query';
 import { shoppingAPI } from 'api/reviews';
+import { queryKey } from 'hooks/queries';
 
 export const useGetShoppingMallReviewInfo = (productURL: string) => {
   return useQuery(
-    ['useGetShoppingMallReviewInfo', productURL],
+    queryKey.shoppingMallReviewInfo(productURL),
     () => shoppingAPI.getShoppingMallReviewInfo(encodeURI(productURL)),
     {
       enabled: !!productURL,
@@ -16,7 +17,7 @@ export const useGetShoppingMallReviewList = (
   sort: 'BEST' | 'NEWEST'
 ) => {
   return useQuery(
-    ['useGetShoppingMallReviewList', productURL, sort],
+    queryKey.shoppingMallReviewList(productURL, sort),
     () => shoppingAPI.getShoppingMallReviewList(encodeURI(productURL), sort),
     {
       enabled: !!productURL,

--- a/hooks/queries/sns.ts
+++ b/hooks/queries/sns.ts
@@ -17,13 +17,11 @@ import useIntersectionObserver from 'hooks/useIntersectionObserver';
 import useInfiniteScrollQuery from './useInfiniteScrollQuery';
 import { CommentResponseType, ReviewResponseType } from 'typings/reviews';
 import { selectedUserState } from 'states/reviews';
-
-export const FOLLOWING_DICTIONARY_KEY = ['FollowingDictionary'];
-export const FOLLOW_SUGGESTION_KEY = ['followSuggestion'];
+import { queryKey } from 'hooks/queries';
 
 export const useGetFollowerList = (nickname: string) => {
   const followerListInfiniteQuery = useInfiniteScrollQuery({
-    queryKey: ['useGetFollowerList'],
+    queryKey: queryKey.followerList(),
     getNextPage: (nextRequest) => {
       return snsAPI.getFollowerList({
         nickname,
@@ -70,7 +68,7 @@ export const useGetFollowingList = (nickname: string) => {
     FollowType,
     'userId'
   >({
-    queryKey: ['useGetFollowingList'],
+    queryKey: queryKey.followingList(),
     getNextPage: (nextRequest) => {
       return snsAPI.getFollowingList({
         nickname,
@@ -81,9 +79,9 @@ export const useGetFollowingList = (nickname: string) => {
     nextRequest: 'userId',
     options: {
       onSuccess: (data) => {
-        queryClient.cancelQueries(FOLLOWING_DICTIONARY_KEY);
+        queryClient.cancelQueries(queryKey.followingDictionary());
         queryClient.fetchQuery({
-          queryKey: FOLLOWING_DICTIONARY_KEY,
+          queryKey: queryKey.followingDictionary(),
           queryFn: () => {
             const followingList = linkageInfiniteScrollData(data);
 
@@ -108,7 +106,7 @@ export const useGetFollowingList = (nickname: string) => {
 };
 
 export const useGetUserReviews = (nickname: string, reviewId?: number) => {
-  return useQuery(['reviews', nickname], () =>
+  return useQuery(queryKey.userReviews(nickname), () =>
     snsAPI.getUserReviews(nickname, reviewId)
   );
 };
@@ -127,11 +125,13 @@ const getNewSuggestArray = (array: FollowType[], nickname: string) => {
 };
 
 export const useGetOneReview = (reviewId: number) => {
-  return useQuery(['review', reviewId], () => snsAPI.getOneReview(reviewId));
+  return useQuery(queryKey.userOneReview(reviewId), () =>
+    snsAPI.getOneReview(reviewId)
+  );
 };
 
 export const useGetReviewComments = (reviewId: number) => {
-  return useQuery(['review', 'comments', reviewId], () =>
+  return useQuery(queryKey.reviewComments(reviewId), () =>
     snsAPI.getReviewComments(reviewId)
   );
 };
@@ -148,7 +148,7 @@ export const usePostReviewComment = (reviewId: number) => {
     }) => snsAPI.postReviewComment(reviewId, createdComment),
     {
       onSuccess: () => {
-        queryClient.invalidateQueries(['review', 'comments', reviewId]);
+        queryClient.invalidateQueries(queryKey.reviewComments(reviewId));
       },
       onError: (err) => {
         alert(err);
@@ -165,12 +165,9 @@ export const usePostlikeToComment = (reviewId: number, commentId: number) => {
       snsAPI.postLikeToComment(commentId),
     {
       onSuccess: () => {
-        queryClient.invalidateQueries([
-          'review',
-          'comment',
-          reviewId,
-          commentId,
-        ]);
+        queryClient.invalidateQueries(
+          queryKey.reviewComment(reviewId, commentId)
+        );
       },
     }
   );
@@ -180,16 +177,16 @@ export const usePostlikeToComment = (reviewId: number, commentId: number) => {
 export const useFollowAndUnFollow = () => {
   const queryClient = useQueryClient();
   const originFollowingDictionary = queryClient.getQueryData(
-    FOLLOWING_DICTIONARY_KEY
+    queryKey.followingDictionary()
   ) as FollowingDictionary;
   const originFollowSuggestion = queryClient.getQueryData(
-    FOLLOW_SUGGESTION_KEY
+    queryKey.followerSuggestion()
   ) as FollowType[];
 
   const onFollowOptimisticUpdate = (targetUserNickname: string) => {
     optimisticUpdateByReactQuery({
       queryClient,
-      queryKey: FOLLOWING_DICTIONARY_KEY,
+      queryKey: queryKey.followingDictionary(),
       newData: {
         ...originFollowingDictionary,
         [targetUserNickname]: {},
@@ -198,7 +195,7 @@ export const useFollowAndUnFollow = () => {
 
     optimisticUpdateByReactQuery({
       queryClient,
-      queryKey: FOLLOW_SUGGESTION_KEY,
+      queryKey: queryKey.followerSuggestion(),
       newData: getNewSuggestArray(originFollowSuggestion, targetUserNickname),
     });
   };
@@ -209,20 +206,20 @@ export const useFollowAndUnFollow = () => {
 
     optimisticUpdateByReactQuery({
       queryClient,
-      queryKey: FOLLOWING_DICTIONARY_KEY,
+      queryKey: queryKey.followingDictionary(),
       newData: restIsFollowingDictionary,
     });
 
     optimisticUpdateByReactQuery({
       queryClient,
-      queryKey: FOLLOW_SUGGESTION_KEY,
+      queryKey: queryKey.followerSuggestion(),
       newData: getNewSuggestArray(originFollowSuggestion, targetUserNickname),
     });
   };
 
   const resetOriginFollowingDictionary = () => {
     queryClient.setQueryData(
-      FOLLOWING_DICTIONARY_KEY,
+      queryKey.followingDictionary(),
       originFollowingDictionary
     );
   };
@@ -275,7 +272,7 @@ export const useFollowAndUnFollow = () => {
 
 export const useGetSocialProfile = (nickname: string) => {
   const socialProfileQuery = useQuery(
-    ['socialProfile'],
+    queryKey.socialProfile(),
     () => snsAPI.getProfile(nickname),
     {
       enabled: !!nickname,
@@ -286,7 +283,7 @@ export const useGetSocialProfile = (nickname: string) => {
 };
 export const useGetInfiniteSocialReviews = (nickname: string) => {
   const infiniteQuery = useInfiniteScrollQuery<SocialReview, 'reviewId'>({
-    queryKey: ['socialMyReviews', nickname],
+    queryKey: queryKey.socialMyReviews(nickname),
     getNextPage: (nextRequest) => {
       return snsAPI.getUserReviews(nickname, nextRequest);
     },
@@ -305,7 +302,7 @@ export const useGetInfiniteSocialReviews = (nickname: string) => {
 export const useGetInfiniteFeed = () => {
   const selectedUser = useRecoilValue(selectedUserState);
   const infiniteQuery = useInfiniteScrollQuery<ReviewResponseType, 'reviewId'>({
-    queryKey: ['useGetInfiniteFeed', selectedUser],
+    queryKey: queryKey.userInfiniteFeed(selectedUser),
     getNextPage: (nextRequest) => {
       return selectedUser === ''
         ? snsAPI.getInfiniteFeed(nextRequest)
@@ -324,7 +321,7 @@ export const useGetInfiniteFeed = () => {
 
 export const useGetInfiniteScrapList = () => {
   const infiniteQuery = useInfiniteScrollQuery<ReviewResponseType, 'reviewId'>({
-    queryKey: ['useGetInfiniteScrapList'],
+    queryKey: queryKey.socialInfiniteFeed(),
     getNextPage: (nextRequest) => snsAPI.getInfiniteScrapList(nextRequest),
     nextRequest: 'reviewId',
   });
@@ -338,7 +335,7 @@ export const useGetInfiniteScrapList = () => {
 };
 
 export const useGetRecentUpdatedUsers = () => {
-  const recentUpdatedUserQuery = useQuery(['recentUpdatedUser'], () =>
+  const recentUpdatedUserQuery = useQuery(queryKey.recentUpdatedUser(), () =>
     snsAPI.getRecentUpdatedUsers()
   );
 
@@ -347,7 +344,7 @@ export const useGetRecentUpdatedUsers = () => {
 
 export const useGetFollowSuggestion = () => {
   return useQuery<FollowType[]>(
-    ['followSuggestion'],
+    queryKey.followerSuggestion(),
     () => snsAPI.getFollowSuggestion(),
     {
       refetchOnWindowFocus: false,

--- a/hooks/queries/sns.ts
+++ b/hooks/queries/sns.ts
@@ -272,7 +272,7 @@ export const useFollowAndUnFollow = () => {
 
 export const useGetSocialProfile = (nickname: string) => {
   const socialProfileQuery = useQuery(
-    queryKey.socialProfile(),
+    queryKey.socialUserProfile(),
     () => snsAPI.getProfile(nickname),
     {
       enabled: !!nickname,

--- a/hooks/queries/users.ts
+++ b/hooks/queries/users.ts
@@ -4,13 +4,12 @@ import { UserProfileResponseType } from 'typings/account';
 
 import { isLoginState } from 'states/isLogin';
 import { useRecoilValue } from 'recoil';
-
-const USER_PROFILE_QUERY = 'userProfile';
+import { queryKey } from 'hooks/queries';
 
 const useUserProfile = () => {
   const isLogin = useRecoilValue(isLoginState);
   const { data: userData } = useQuery<UserProfileResponseType>(
-    [USER_PROFILE_QUERY, isLogin],
+    queryKey.myProfile(isLogin),
     usersAPI.getUserProfile,
     {
       enabled: !!isLogin,

--- a/hooks/useGetIsFollowing.tsx
+++ b/hooks/useGetIsFollowing.tsx
@@ -1,8 +1,7 @@
 import { useQuery } from '@tanstack/react-query';
-import {
-  FOLLOWING_DICTIONARY_KEY,
-  useGetFollowingList,
-} from 'hooks/queries/sns';
+
+import { queryKey } from 'hooks/queries';
+import { useGetFollowingList } from 'hooks/queries/sns';
 import useUserProfile from 'hooks/queries/users';
 import { FollowingDictionary } from 'typings/sns';
 
@@ -10,7 +9,7 @@ export const useGetIsFollowing = (nickname: string) => {
   const userData = useUserProfile();
   useGetFollowingList(userData?.nickname || '');
   const { data: isFollowingDictionary } = useQuery<FollowingDictionary>(
-    FOLLOWING_DICTIONARY_KEY,
+    queryKey.followingDictionary(),
     {
       networkMode: 'offlineFirst',
     }

--- a/hooks/useReaction.tsx
+++ b/hooks/useReaction.tsx
@@ -1,6 +1,7 @@
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 
 import { snsAPI } from 'api/sns';
+import { queryKey } from 'hooks/queries';
 import { ReactionType } from 'typings/reviews';
 
 const useReaction = (reviewId: number) => {
@@ -9,8 +10,8 @@ const useReaction = (reviewId: number) => {
     (reaction: ReactionType) => snsAPI.toggleReaction(reviewId, reaction),
     {
       onSuccess: () => {
-        queryClient.invalidateQueries(['useGetInfiniteFeed']);
-        queryClient.invalidateQueries(['review', reviewId]);
+        queryClient.invalidateQueries(queryKey.socialInfiniteFeed());
+        queryClient.invalidateQueries(queryKey.review(reviewId));
       },
     }
   );

--- a/hooks/useScrap.tsx
+++ b/hooks/useScrap.tsx
@@ -1,7 +1,6 @@
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { snsAPI } from 'api/sns';
-
-const INFINITE_FEED_QUERY_KEY = 'useGetInfiniteFeed';
+import { queryKey } from 'hooks/queries';
 
 const useScrap = (reviewId: number) => {
   const queryClient = useQueryClient();
@@ -9,8 +8,8 @@ const useScrap = (reviewId: number) => {
     () => snsAPI.addScrap(reviewId),
     {
       onSuccess: () => {
-        queryClient.invalidateQueries([INFINITE_FEED_QUERY_KEY]);
-        queryClient.invalidateQueries(['review', reviewId]);
+        queryClient.invalidateQueries(queryKey.socialInfiniteFeed());
+        queryClient.invalidateQueries(queryKey.review(reviewId));
       },
     }
   );
@@ -18,8 +17,8 @@ const useScrap = (reviewId: number) => {
     () => snsAPI.deleteScrap(reviewId),
     {
       onSuccess: () => {
-        queryClient.invalidateQueries([INFINITE_FEED_QUERY_KEY]);
-        queryClient.invalidateQueries(['review', reviewId]);
+        queryClient.invalidateQueries(queryKey.socialInfiniteFeed());
+        queryClient.invalidateQueries(queryKey.review(reviewId));
       },
     }
   );


### PR DESCRIPTION
## 📌 전반적인 개발 내용
useQuery 내부에 하드코딩 되어있던 queryKey를 객체로 묶어서 관리하도록 변경
> 현재는 1차적으로 하드 코딩 되어있던 queryKey를 외부 객체로 분리해내는거에 집중하였습니다. 
dashboard, project, review, statistics 등으로 api 함수를 묶은것처럼 queryKey도 동일하게 할 수 있을것으로 보입니다.

<br>

## 💻 변경 내용
- hooks/queries/index.ts: queryKey object 생성
- querykey를 사용하는 모든 react query 관련 hook에서  queryKey object를 import 하여 사용하도록 수정

<br>

## ✅ 관심 리뷰
변경사항 반영 이후 아래와 같은 이슈 발생
- _모달이 닫혀도 background 가 남아있는 이슈_ (이슈 재발생)
- _'social/user' URL에서 query string이 변경 되었다가 다시 이전 브라우저 히스토리로 돌아오는 이슈_ 
